### PR TITLE
Add keyboard shortcuts to trigger search modal

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -2,108 +2,94 @@ import groupBy from "lodash/groupBy";
 import truncate from "lodash/truncate";
 import { FlexSearch } from "flexsearch/dist/flexsearch.compact";
 import { Validator } from "@cfworker/json-schema";
-import { iconSprite } from "./utils";
+import { iconSprite, isMac, isReadMode } from "./utils";
 
 const input = document.querySelector("#search-input");
 
 const init = (input, searchConfig) => {
-  input.removeEventListener("focus", init);
+	input.removeEventListener("focus", init);
 
-  const indexCfgDefaults = {
-    tokenize: "forward",
-  };
-  const indexCfg = searchConfig.indexConfig
-    ? searchConfig.indexConfig
-    : indexCfgDefaults;
-  const dataUrl = searchConfig.dataFile;
+	const indexCfgDefaults = {
+		tokenize: "forward",
+	};
+	const indexCfg = searchConfig.indexConfig ? searchConfig.indexConfig : indexCfgDefaults;
+	const dataUrl = searchConfig.dataFile;
 
-  indexCfg.document = {
-    key: "id",
-    index: ["title", "content", "description"],
-    store: ["title", "href", "parent", "description"],
-  };
+	indexCfg.document = {
+		key: "id",
+		index: ["title", "content", "description"],
+		store: ["title", "href", "parent", "description"],
+	};
 
-  const index = new FlexSearch.Document(indexCfg);
-  window.searchIndex = index;
+	const index = new FlexSearch.Document(indexCfg);
+	window.searchIndex = index;
 
-  getJson(dataUrl, function (data) {
-    data.forEach((obj) => {
-      window.searchIndex.add(obj);
-    });
-  });
+	getJson(dataUrl, function (data) {
+		data.forEach((obj) => {
+			window.searchIndex.add(obj);
+		});
+	});
 };
 
 const search = (input, results, searchConfig) => {
-  const searchCfg = {
-    enrich: true,
-    limit: 5,
-  };
+	const searchCfg = {
+		enrich: true,
+		limit: 5,
+	};
 
-  while (results.firstChild) {
-    results.removeChild(results.firstChild);
-  }
+	while (results.firstChild) {
+		results.removeChild(results.firstChild);
+	}
 
-  if (!input.value) {
-    return results.classList.remove("has-hits");
-  }
+	if (!input.value) {
+		return results.classList.remove("has-hits");
+	}
 
-  let searchHits = flattenHits(
-    window.searchIndex.search(input.value, searchCfg)
-  );
+	let searchHits = flattenHits(window.searchIndex.search(input.value, searchCfg));
 
-  if (searchHits.length < 1) {
-    const noResult = document.createElement("li");
-    noResult.classList.add(
-      "p-3",
-      "flex",
-      "flex-col",
-      "items-center",
-      "text-center"
-    );
-    noResult.innerHTML = `<div class="mb-3">${iconSprite(
-      "no-result",
-      40,
-      40
-    )}</div>
+	if (searchHits.length < 1) {
+		const noResult = document.createElement("li");
+		noResult.classList.add("p-3", "flex", "flex-col", "items-center", "text-center");
+		noResult.innerHTML = `<div class="mb-3">${iconSprite("no-result", 40, 40)}</div>
 								No results have been found, Please <br/>rephrase your query!`;
-    results.appendChild(noResult);
-    return results.classList.remove("has-hits");
-  }
+		results.appendChild(noResult);
+		return results.classList.remove("has-hits");
+	}
 
-  results.classList.add("has-hits");
+	results.classList.add("has-hits");
 
-  if (searchConfig.showParent === true) {
-    searchHits = groupBy(searchHits, (hit) => hit.parent);
-  }
+	if (searchConfig.showParent === true) {
+		searchHits = groupBy(searchHits, (hit) => hit.parent);
+	}
 
-  const items = [];
+	const items = [];
 
-  if (searchConfig.showParent === true) {
-    for (const section in searchHits) {
-      const item = document.createElement("li"),
-        title = item.appendChild(document.createElement("span")),
-        subList = item.appendChild(document.createElement("ul"));
+	if (searchConfig.showParent === true) {
+		for (const section in searchHits) {
+			const item = document.createElement("li"),
+				title = item.appendChild(document.createElement("span")),
+				subList = item.appendChild(document.createElement("ul"));
 
-      if (!section) {
-        title.remove();
-      }
-      title.classList.add("gdoc-search__section");
-      title.textContent = section;
-      createLinks(searchHits[section], subList, searchConfig.showDescription);
+			if (!section) {
+				title.remove();
+			}
+			title.classList.add("gdoc-search__section");
+			title.textContent = section;
+			createLinks(searchHits[section], subList, searchConfig.showDescription);
 
-      items.push(item);
-    }
-  } else {
-    const item = document.createElement("li"),
-      subList = item.appendChild(document.createElement("ul"));
-    createLinks(searchHits, subList, searchConfig.showDescription);
+			items.push(item);
+		}
+	} else {
+		const item = document.createElement("li"),
+			subList = item.appendChild(document.createElement("ul"));
+		createLinks(searchHits, subList, searchConfig.showDescription);
 
-    items.push(item);
-  }
+		items.push(item);
+	}
 
-  items.forEach((item) => {
-    results.appendChild(item);
-  });
+	items.forEach((item) => {
+		results.appendChild(item);
+	});
 };
 
 /**
@@ -113,87 +99,82 @@ const search = (input, results, searchConfig) => {
  * @returns {Array} If target is not specified, returns an array of built links
  */
 const createLinks = (pages, target, showDesc) => {
-  const items = [];
+	const items = [];
 
-  for (const page of pages) {
-    const item = document.createElement("li"),
-      a = item.appendChild(document.createElement("a")),
-      entry = a.appendChild(document.createElement("span"));
+	for (const page of pages) {
+		const item = document.createElement("li"),
+			a = item.appendChild(document.createElement("a")),
+			entry = a.appendChild(document.createElement("span"));
 
-    a.href = page.href;
-    entry.textContent = page.title;
-    a.setAttribute(
-      "class",
-      "text-body py-2 px-3 block hover:bg-slate-500/10 dark:hover:bg-dark-100/50 focus:outline-none focus:bg-slate-300/80 rounded"
-    );
+		a.href = page.href;
+		entry.textContent = page.title;
+		a.setAttribute("class", "text-body py-2 px-3 block hover:bg-slate-500/10 dark:hover:bg-dark-100/50 focus:outline-none focus:bg-slate-300/80 rounded");
 
-    if (showDesc === true) {
-      const desc = a.appendChild(document.createElement("span"));
-      desc.setAttribute("gdoc-search__entry--description");
-      desc.textContent = truncate(page.description, {
-        length: 55,
-        separator: " ",
-      });
-    }
+		if (showDesc === true) {
+			const desc = a.appendChild(document.createElement("span"));
+			desc.setAttribute("gdoc-search__entry--description");
+			desc.textContent = truncate(page.description, {
+				length: 55,
+				separator: " ",
+			});
+		}
 
-    if (target) {
-      target.appendChild(item);
-      continue;
-    }
+		if (target) {
+			target.appendChild(item);
+			continue;
+		}
 
-    items.push(item);
-  }
+		items.push(item);
+	}
 
-  return items;
+	return items;
 };
 
 const fetchErrors = (response) => {
-  if (!response.ok) {
-    throw Error(
-      "Failed to fetch '" + response.url + "': " + response.statusText
-    );
-  }
-  return response;
+	if (!response.ok) {
+		throw Error("Failed to fetch '" + response.url + "': " + response.statusText);
+	}
+	return response;
 };
 
 function getJson(src, callback) {
-  fetch(src)
-    .then(fetchErrors)
-    .then((response) => response.json())
-    .then((json) => callback(json))
-    .catch(function (error) {
-      if (error instanceof AggregateError) {
-        console.error(error.message);
-        error.errors.forEach((element) => {
-          console.error(element);
-        });
-      } else {
-        console.error(error);
-      }
-    });
+	fetch(src)
+		.then(fetchErrors)
+		.then((response) => response.json())
+		.then((json) => callback(json))
+		.catch(function (error) {
+			if (error instanceof AggregateError) {
+				console.error(error.message);
+				error.errors.forEach((element) => {
+					console.error(element);
+				});
+			} else {
+				console.error(error);
+			}
+		});
 }
 
 const flattenHits = (results) => {
-  const items = [];
-  const map = new Map();
+	const items = [];
+	const map = new Map();
 
-  for (const field of results) {
-    for (const page of field.result) {
-      if (!map.has(page.doc.href)) {
-        map.set(page.doc.href, true);
-        items.push(page.doc);
-      }
-    }
-  }
+	for (const field of results) {
+		for (const page of field.result) {
+			if (!map.has(page.doc.href)) {
+				map.set(page.doc.href, true);
+				items.push(page.doc);
+			}
+		}
+	}
 
-  return items;
+	return items;
 };
 
 const urlPath = (rawURL) => {
-  let parser = document.createElement("a");
-  parser.href = rawURL;
+	let parser = document.createElement("a");
+	parser.href = rawURL;
 
-  return parser.pathname;
+	return parser.pathname;
 };
 
 /**
@@ -205,85 +186,108 @@ const urlPath = (rawURL) => {
  * @returns {string} The combined URL
  */
 const combineURLs = (baseURL, relativeURL) => {
-  return relativeURL
-    ? baseURL.replace(/\/+$/, "") + "/" + relativeURL.replace(/^\/+/, "")
-    : baseURL;
+	return relativeURL ? baseURL.replace(/\/+$/, "") + "/" + relativeURL.replace(/^\/+/, "") : baseURL;
 };
 
 export const siteSearch = () => {
-  const results = document.querySelector("#search-results");
-  const basePath = urlPath(input ? input.dataset.siteBaseUrl : "");
-  const lang = input ? input.dataset.siteLang : "";
+	const results = document.querySelector("#search-results");
+	const basePath = urlPath(input ? input.dataset.siteBaseUrl : "");
+	const lang = input ? input.dataset.siteLang : "";
 
-  const configSchema = {
-    type: "object",
-    properties: {
-      dataFile: {
-        type: "string",
-      },
-      indexConfig: {
-        type: ["object", "null"],
-      },
-      showParent: {
-        type: "boolean",
-      },
-      showDescription: {
-        type: "boolean",
-      },
-    },
-    additionalProperties: false,
-  };
-  const validator = new Validator(configSchema);
+	const configSchema = {
+		type: "object",
+		properties: {
+			dataFile: {
+				type: "string",
+			},
+			indexConfig: {
+				type: ["object", "null"],
+			},
+			showParent: {
+				type: "boolean",
+			},
+			showDescription: {
+				type: "boolean",
+			},
+		},
+		additionalProperties: false,
+	};
+	const validator = new Validator(configSchema);
 
-  if (!input) return;
+	if (!input) return;
 
-  getJson(
-    combineURLs(basePath, "/search/" + lang + ".config.min.json"),
-    function (searchConfig) {
-      const validationResult = validator.validate(searchConfig);
+	getJson(combineURLs(basePath, "/search/" + lang + ".config.min.json"), function (searchConfig) {
+		const validationResult = validator.validate(searchConfig);
 
-      if (!validationResult.valid)
-        throw AggregateError(
-          validationResult.errors.map(
-            (err) => new Error("Validation error: " + err.error)
-          ),
-          "Schema validation failed"
-        );
+		if (!validationResult.valid)
+			throw AggregateError(
+				validationResult.errors.map((err) => new Error("Validation error: " + err.error)),
+				"Schema validation failed"
+			);
 
-      if (input) {
-        input.addEventListener("focus", () => {
-          init(input, searchConfig);
-        });
-        input.addEventListener("keyup", () => {
-          search(input, results, searchConfig);
-        });
-      }
-    }
-  );
+		if (input) {
+			input.addEventListener("focus", () => {
+				init(input, searchConfig);
+			});
+			input.addEventListener("keyup", () => {
+				search(input, results, searchConfig);
+			});
+		}
+	});
 
-  // Clear search
-  const ROOT = document.documentElement;
-  const SEARCH_ELEM = document.getElementById("search");
-  const SEARCH_TOGGLE_ELEMS = document.querySelectorAll(".search-toggle");
-  const searchClear = document.querySelectorAll(".search-clear");
+	// Clear search
+	const ROOT = document.documentElement;
+	const SEARCH_ELEM = document.getElementById("search");
+	const SEARCH_TOGGLE_ELEMS = document.querySelectorAll(".search-toggle");
+	const searchClear = document.querySelectorAll(".search-clear");
 
-  if (SEARCH_ELEM) {
-    searchClear.forEach((elem) => {
-      elem.addEventListener("click", () => {
-        if (ROOT.classList.contains("read-mode")) {
-          SEARCH_ELEM.classList.add("rm:hidden");
-          input.value = "";
-        } else {
-          input.value = "";
-        }
-      });
-    });
+	if (SEARCH_ELEM) {
+		searchClear.forEach((elem) => {
+			elem.addEventListener("click", () => {
+				if (isReadMode()) {
+					SEARCH_ELEM.classList.add("rm:hidden");
+					input.value = "";
+				} else {
+					input.value = "";
+				}
+			});
+		});
 
-    SEARCH_TOGGLE_ELEMS.forEach((elem) => {
-      elem.addEventListener("click", () => {
-        SEARCH_ELEM.classList.remove("rm:hidden");
-        input.focus();
-      });
-    });
-  }
+		SEARCH_TOGGLE_ELEMS.forEach((elem) => {
+			elem.addEventListener("click", () => {
+				SEARCH_ELEM.classList.remove("rm:hidden");
+				input.focus();
+			});
+		});
+
+		// Keybaord shortcuts
+		const SEARCH_SHORTCUT_ELEMS = document.querySelectorAll(".search-shortcut");
+		const SEARCH_SHORTCUT = isMac() ? "⌘K" : "Ctrl K";
+
+		SEARCH_SHORTCUT_ELEMS.forEach((elem) => {
+			elem.textContent = SEARCH_SHORTCUT;
+		});
+
+		// Set keyboard shortcut for search
+		document.addEventListener("keydown", (e) => {
+			let metaKey = isMac() ? e.metaKey : e.ctrlKey;
+
+			// Focus search input
+			if (metaKey && e.key === "k") {
+				if (isReadMode()) {
+					SEARCH_ELEM.classList.remove("rm:hidden");
+					input.focus();
+				} else {
+					input.focus();
+				}
+				e.preventDefault();
+			}
+
+			// Clear search
+			if (e.key === "Escape") {
+				SEARCH_ELEM.classList.add("rm:hidden");
+				input.value = "";
+			}
+		});
+	}
 };

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -4,3 +4,15 @@ export const iconSprite = (name, width = 24, height = 24) => {
                 <use xlink:href="/img/svg-sprite.svg#${name}"></use>
             </svg>`;
 };
+
+// Find out the platform is MAC or not
+export const isMac = () => {
+	const platform = navigator?.userAgentData?.platform || navigator?.platform;
+	return platform.toUpperCase().indexOf("MAC") >= 0;
+};
+
+// Read mode
+export const isReadMode = () => {
+	const ROOT = document.documentElement;
+	return ROOT.classList.contains("read-mode");
+};

--- a/layouts/partials/platform-menu.html
+++ b/layouts/partials/platform-menu.html
@@ -30,11 +30,17 @@
 		{{ end }}
 		<button
 			type="button"
-			class="search-toggle ml-auto hidden h-8 w-8 place-content-center rounded text-body hover:bg-light-300 nrm:hidden dark:border-slate-500 dark:hover:bg-dark-300 lg:grid"
+			class="search-toggle group -mr-2 ml-auto hidden h-11 w-11 place-content-center place-items-center rounded text-muted hover:bg-light-300 hover:text-body nrm:hidden dark:border-slate-500 dark:hover:bg-dark-300 lg:grid"
 		>
-			<svg class="h-4 w-4">
+			<svg class="h-3.5 w-3.5">
 				<use xlink:href="/img/svg-sprite.svg#search"></use>
 			</svg>
+
+			<i
+				class="search-shortcut mt-1 rounded-sm border border-light-500 p-0.5 text-xs not-italic leading-none group-hover:bg-light-100 dark:border-dark-400 dark:group-hover:bg-dark-200"
+			></i>
+
+			<span class="sr-only">Search</span>
 		</button>
 	</nav>
 </div>

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -7,26 +7,36 @@
 			type="text"
 			id="search-input"
 			class="peer z-[2] h-11 w-full rounded bg-white px-3 pl-10 pr-10 text-sm
-		text-body placeholder:text-muted valid:rounded-br-none valid:rounded-bl-none focus:outline-none dark:bg-dark-100"
+		text-body placeholder:text-muted valid:rounded-bl-none valid:rounded-br-none focus:outline-none dark:bg-dark-100"
 			placeholder="{{ i18n "form_placeholder_search" }}"
 			data-site-base-url="{{ .Site.BaseURL }}"
 			data-site-lang="{{ .Site.Language.Lang }}"
 			required
 		/>
 
+		<i class="search-shortcut absolute right-4 top-3.5 z-[2] text-xs not-italic peer-valid:hidden rm:hidden"></i>
+
 		<button
-			class="search-clear absolute right-2.5 top-0 bottom-0 z-[5] my-auto hidden h-6 w-6 place-content-center rounded text-muted hover:bg-light-200 peer-valid:grid rm:grid dark:hover:bg-dark-200"
+			class="search-clear absolute bottom-0 right-2.5 top-0 z-[5] my-auto hidden h-6 w-6 place-content-center rounded text-muted hover:bg-light-200 peer-valid:grid rm:grid dark:hover:bg-dark-200"
+			type="button"
 		>
 			<svg class="h-2 w-2">
 				<use xlink:href="/img/svg-sprite.svg#close"></use>
 			</svg>
+			<span class="sr-only">Close search</span>
 		</button>
 
 		<ul
 			id="search-results"
-			class="absolute top-full left-0 z-[2] hidden w-full rounded-bl rounded-br bg-light-200 p-3 text-sm text-muted peer-valid:block dark:bg-dark-0"
+			class="absolute left-0 top-full z-[2] hidden w-full rounded-bl rounded-br bg-light-200 p-3 text-sm text-muted peer-valid:block dark:bg-dark-0"
 		></ul>
 
-		<i class="search-clear fixed top-0 left-0 z-[1] hidden h-full w-full bg-black/25 peer-valid:block rm:block dark:bg-[#10151cd9]"></i>
+		<button
+			type="button"
+			role="button"
+			class="search-clear fixed left-0 top-0 z-[1] hidden h-full w-full bg-black/25 peer-valid:block rm:block dark:bg-[#10151cd9]"
+		>
+			<span class="sr-only">Close search</span>
+		</button>
 	</div>
 </div>


### PR DESCRIPTION
How to test:
- Use `⌘+K` (mac) or `Ctrl + K` (other OSs) to focus/trigger the search modal
- Use `esc` to dismiss and clear the search input/modal.