### PR TITLE
Add docs-switch menu

### DIFF
--- a/layouts/partials/docs-menu.html
+++ b/layouts/partials/docs-menu.html
@@ -1,0 +1,35 @@
+{{ if .Site.Menus.docs }}
+	<div class="-bottom-10 right-7 z-[1] ml-6 flex items-center whitespace-nowrap text-xs rm:right-20 lg:absolute">
+		<div class="text-headings mr-3 hidden font-medium lg:block">Go to:</div>
+		<div class="group relative">
+			<div
+				class="flex h-8 items-center rounded border border-white/25 bg-transparent px-2.5 font-medium text-white group-hover:rounded-b-none group-hover:bg-white group-hover:text-heading dark:border-dark-300 dark:bg-transparent dark:text-heading dark:group-hover:bg-transparent lg:border-light-300 lg:bg-white lg:text-heading"
+			>
+				<span class="block p-px">{{ (index .Site.Menus.docs 0).Name }}</span>
+
+				<svg class="ml-2 mr-0.5 mt-0.5 flex-shrink-0" width="9" height="5">
+					<use xlink:href="/img/svg-sprite.svg#chevron-down"></use>
+				</svg>
+			</div>
+
+			<div
+				class="absolute left-0 top-full z-10 -mt-px hidden w-full flex-col gap-px rounded-b border border-light-200 bg-white p-1 group-hover:flex dark:border-dark-300 dark:bg-dark-100"
+			>
+				{{ range .Site.Menus.docs }}
+					<a
+						href="{{ .URL }}"
+						target="_blank"
+						rel="noreferrer"
+						class="rounde {{ if .Params.Current }}
+							bg-light-300 dark:bg-dark-300 pointer-events-none text-heading
+						{{ else }}
+							text-muted
+						{{ end }} flex items-center whitespace-nowrap rounded py-1.5 pl-2.5 pr-6 hover:bg-light-100 hover:text-body dark:hover:bg-dark-200"
+					>
+						{{ .Name }}
+					</a>
+				{{ end }}
+			</div>
+		</div>
+	</div>
+{{ end }}

--- a/layouts/partials/platform-menu.html
+++ b/layouts/partials/platform-menu.html
@@ -30,14 +30,14 @@
 		{{ end }}
 		<button
 			type="button"
-			class="search-toggle group -mr-2 ml-auto hidden h-11 w-11 place-content-center place-items-center rounded text-muted hover:bg-light-300 hover:text-body nrm:hidden dark:border-slate-500 dark:hover:bg-dark-300 lg:grid"
+			class="search-toggle group -mr-2 ml-auto hidden h-11 w-11 place-content-center place-items-center rounded text-muted hover:bg-light-300 hover:text-body nrm:hidden dark:hover:bg-dark-200 lg:grid"
 		>
 			<svg class="h-3.5 w-3.5">
 				<use xlink:href="/img/svg-sprite.svg#search"></use>
 			</svg>
 
 			<i
-				class="search-shortcut mt-1 rounded-sm border border-light-500 p-0.5 text-xs not-italic leading-none group-hover:bg-light-100 dark:border-dark-400 dark:group-hover:bg-dark-200"
+				class="search-shortcut mt-1 rounded-sm border border-light-500 p-0.5 text-[0.6rem] not-italic leading-none group-hover:bg-light-100 dark:border-dark-400 dark:group-hover:bg-dark-200"
 			></i>
 
 			<span class="sr-only">Search</span>

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,4 +1,4 @@
-<div class="left-0 right-0 top-0 z-[1] items-center p-5 rm:fixed rm:hidden rm:lg:top-[1.875rem]" id="search">
+<div class="left-0 right-0 top-0 z-[1] items-center p-5 rm:fixed rm:hidden nrm:pb-10 rm:lg:top-[1.875rem]" id="search">
 	<div class="relative mx-auto flex w-full max-w-xl">
 		<svg class="absolute left-4 top-3.5 z-[3] text-black dark:text-body" width="14" height="14">
 			<use xlink:href="/img/svg-sprite.svg#search"></use>

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -1,11 +1,11 @@
-<header class="header relative z-10 flex-shrink-0 bg-[#031733] text-md nrm:pb-5 dark:bg-dark-0" id="header">
+<header class="header relative z-10 flex-shrink-0 bg-[#031733] text-md dark:bg-dark-0" id="header">
 	<div class="relative mx-auto w-full px-5 nrm:max-w-container lg:px-7">
 		<div class="flex h-12 items-center border-white/25 nrm:mb-2 nrm:border-b dark:border-[#273140]">
 			<svg class="flex-shrink-0 text-theme-red dark:text-heading" width="100" height="15">
 				<use xlink:href="/img/svg-sprite.svg#minio-logo"></use>
 			</svg>
 
-			<div class="ml-5 hidden text-sm font-medium text-white nrm:hidden dark:text-heading sm:block">Documentation</div>
+			{{ partial "docs-menu" . }}
 
 			<i class="ml-auto"></i>
 
@@ -28,7 +28,7 @@
 				</svg>
 			</button>
 
-			<div class="bottom-5 right-7 flex nrm:absolute">
+			<div class="bottom-10 right-7 flex nrm:absolute">
 				<button
 					type="button"
 					class="ml-2 grid h-8 w-8 place-content-center rounded border bg-white pt-px text-body hover:opacity-90 dark:border-slate-500 dark:bg-dark-0"
@@ -56,25 +56,27 @@
 
 			{{ range .Site.Menus.main }}
 				<!-- prettier-ignore -->
-				<div class="{{ if not (.Params.Wide) }}relative {{ end }}{{ if eq .Name "Download" }}ml-auto {{ end }}group">
-					<!-- prettier-ignore -->
-					{{ if .HasChildren }}
-					<span class="relative flex items-center py-2 text-white dark:text-body dark:hover:text-heading rm:text-heading cursor-pointer rm:px-3">
+				<div class="{{ if not (.Params.Wide) }}relative {{ end }}{{ if eq .Name " Download" }}ml-auto {{ end
+				}}group">
+				<!-- prettier-ignore -->
+				{{ if .HasChildren }}
+				<span
+					class="relative flex items-center py-2 text-white dark:text-body dark:hover:text-heading rm:text-heading cursor-pointer rm:px-3">
 					{{ else }}
-						{{ if eq .Name "Download" }}
-							<a class="py-1 px-4 flex rounded justify-center text-white rm:text-heading rm:hover:text-white dark:text-body border border-theme-red transition-colors duration-300 dark:border-slate-500 hover:bg-theme-red hover:text-white dark:hover:bg-dark-200 rm:px-3 rm:mx-3 rm:my-4 rm:py-1.5"
-								href="{{ .URL }}">
+					{{ if eq .Name "Download" }}
+					<a class="py-1 px-4 flex rounded justify-center text-white rm:text-heading rm:hover:text-white dark:text-body border border-theme-red transition-colors duration-300 dark:border-slate-500 hover:bg-theme-red hover:text-white dark:hover:bg-dark-200 rm:px-3 rm:mx-3 rm:my-4 rm:py-1.5"
+						href="{{ .URL }}">
 						{{ else }}
-							<a class="relative py-2 flex text-white dark:text-body dark:hover:text-heading rm:text-heading rounded rm:px-3 rm:hover:bg-light-100 drm:hover:bg-dark-200"
-								href="{{ .URL }}">
-						{{ end }}
-					{{ end }}
-					<span class="rm:font-medium">{{ .Name }}</span>
-					{{ if .Params.Dropdown }}
+						<a class="relative py-2 flex text-white dark:text-body dark:hover:text-heading rm:text-heading rounded rm:px-3 rm:hover:bg-light-100 drm:hover:bg-dark-200"
+							href="{{ .URL }}">
+							{{ end }}
+							{{ end }}
+							<span class="rm:font-medium">{{ .Name }}</span>
+							{{ if .Params.Dropdown }}
 					<i
-						class="absolute left-0 right-0 bottom-0 mx-auto inline-block h-0 w-0 border-x-[4px] border-b-[3px] border-l-transparent border-b-white border-r-transparent opacity-0 group-hover:opacity-100 rm:hidden dark:border-b-dark-100"
+						class="absolute bottom-0 left-0 right-0 mx-auto inline-block h-0 w-0 border-x-[4px] border-b-[3px] border-b-white border-l-transparent border-r-transparent opacity-0 group-hover:opacity-100 rm:hidden dark:border-b-dark-100"
 					></i>
-					<svg class="mt-1 ml-2 rm:hidden" width="9" height="5">
+					<svg class="ml-2 mt-1 rm:hidden" width="9" height="5">
 						<use xlink:href="/img/svg-sprite.svg#chevron-down"></use>
 					</svg>
 				{{ else }}
@@ -84,14 +86,14 @@
 						></i>
 					{{ end }}
 				{{ end }}
-					<!-- prettier-ignore -->
-					{{ if .HasChildren }}
-					</span>
-					{{ else }}
-					</a>
-					{{ end }}
+							<!-- prettier-ignore -->
+							{{ if .HasChildren }}
+				</span>
+				{{ else }}
+				</a>
+				{{ end }}
 
-					{{ if .HasChildren }}
+				{{ if .HasChildren }}
 					<div
 						class="{{ if .Params.Wide }}
 							w-full
@@ -119,7 +121,7 @@
 										</span>
 										{{ range .Children }}
 											{{ if .HasChildren }}
-												<div class="flex items-start rounded py-2 px-3 hover:bg-light-100 dark:hover:bg-dark-200">
+												<div class="flex items-start rounded px-3 py-2 hover:bg-light-100 dark:hover:bg-dark-200">
 													<svg class="mr-3 h-8 w-8 rm:hidden">
 														<use xlink:href="/img/svg-sprite.svg#{{ .Pre }}"></use>
 													</svg>
@@ -159,7 +161,7 @@
 						</div>
 					</div>
 				{{ end }}
-				</div>
+			</div>
 			{{ end }}
 		</nav>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,7 @@ module.exports = {
 		fontSize: {
 			xxxs: 6 / 16 + "rem",
 			xxs: 9 / 16 + "rem",
-			xs: 11 / 16 + "rem",
+			xs: 12 / 16 + "rem",
 			sm: 13 / 16 + "rem",
 			md: 15 / 16 + "rem",
 			base: 17 / 16 + "rem",


### PR DESCRIPTION
**Adding menu entries:**

Create a new menu as follows in `config.toml`:

```toml
[menu]
    [[menu.docs]]
        name = "KES Documentation"
        weight = 1
        [menu.docs.params]
            current = true
    [[menu.docs]]
        name = "MinIO Documentation"
        url = "https://min.io/docs"
        weight = 2
```

Make sure to keep the current docs as the first entry with an additional params `current = true`.

I will send a new PR to add the switch menu on the KES parent site once the PR is merged. 