### PR TITLE
Reduce flickering on page load

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,3 +1,11 @@
+<script>
+	var isDmActive = JSON.parse(localStorage.getItem("dark-mode")) || false;
+	let isRmActive = JSON.parse(localStorage.getItem("read-mode")) || false;
+
+	document.documentElement.classList.toggle("read-mode", isRmActive);
+	document.documentElement.classList.toggle("dark", isDmActive);
+</script>
+
 {{ $script := resources.Get "/dist/app.js" }}
 
 {{ if .Site.IsServer }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,6 +1,6 @@
 <script>
 	var isDmActive = JSON.parse(localStorage.getItem("dark-mode")) || false;
-	let isRmActive = JSON.parse(localStorage.getItem("read-mode")) || false;
+	var isRmActive = JSON.parse(localStorage.getItem("read-mode")) || false;
 
 	document.documentElement.classList.toggle("read-mode", isRmActive);
 	document.documentElement.classList.toggle("dark", isDmActive);


### PR DESCRIPTION
Moved dark-mode and read-mode detection scripts to HTML to reduce the flickering on page load.