### PR TITLE
Adding admonitions for improved functionality

### DIFF
--- a/layouts/shortcodes/sub.html
+++ b/layouts/shortcodes/sub.html
@@ -1,0 +1,10 @@
+{{ $key := (.Get 0) }}
+{{ with $key }}
+   {{ with ($.Site.Param .) }}
+      {{ . }}
+   {{ else }}
+      {{ errorf "%s: The specified key does not exist in the site [params] config list" $.Position }}
+   {{ end }}
+{{ else }}
+   {{ errorf "%s : The %q shortcode requires specifying the substitution key." .Position .Name }}
+{{ end }}


### PR DESCRIPTION
# Summary

There is technically a `{{ params PARAM }}` for pulling page-level parameters, but nothing (at a glance) for site-level parameters.

This specifically pulls any params set at the Site `config.toml -> [params]` section.

This opens up similar behavior to our Sphinx docs where we populate `config.toml` with static data that we then pull down into individual pages as-needed. 