### PR TITLE
Build warning fixes

### DIFF
--- a/layouts/partials/head/others.html
+++ b/layouts/partials/head/others.html
@@ -8,7 +8,7 @@
 {{ $utils := resources.Get "dist/utilities.css" }}
 {{ $css := slice $scss $utils | resources.Concat "dist/style.css" }}
 
-{{ if .Site.IsServer }}
+{{ if .hugo.IsServer }}
 	{{ $css := $css | fingerprint }}
 	<link rel="stylesheet" href="{{ $css.Permalink }}" />
 {{ else }}

--- a/layouts/partials/head/others.html
+++ b/layouts/partials/head/others.html
@@ -8,7 +8,7 @@
 {{ $utils := resources.Get "dist/utilities.css" }}
 {{ $css := slice $scss $utils | resources.Concat "dist/style.css" }}
 
-{{ if .hugo.IsServer }}
+{{ if hugo.IsServer }}
 	{{ $css := $css | fingerprint }}
 	<link rel="stylesheet" href="{{ $css.Permalink }}" />
 {{ else }}

--- a/layouts/partials/microformats/opengraph.html
+++ b/layouts/partials/microformats/opengraph.html
@@ -63,6 +63,6 @@
 {{- end }}
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}
-{{- with .Site.Social.facebook_admin }}
+{{- with .Site.Params.Social.facebook_admin }}
   <meta property="fb:admins" content="{{ . }}" />
 {{- end }}

--- a/layouts/partials/microformats/twitter_cards.html
+++ b/layouts/partials/microformats/twitter_cards.html
@@ -10,6 +10,6 @@
 {{- with partial "utils/description" . }}
   <meta name="twitter:description" content="{{ . | plainify | htmlUnescape | chomp }}" />
 {{- end }}
-{{- with .Site.Social.twitter -}}
+{{- with .Site.Params.Social.twitter -}}
   <meta name="twitter:site" content="@{{ . }}" />
 {{- end }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -8,7 +8,7 @@
 
 {{ $script := resources.Get "/dist/app.js" }}
 
-{{ if .Site.IsServer }}
+{{ if .hugo.IsServer }}
 	{{ $script := $script | fingerprint }}
 	<script src="{{ $script.Permalink }}"></script>
 {{ else }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -8,7 +8,7 @@
 
 {{ $script := resources.Get "/dist/app.js" }}
 
-{{ if .hugo.IsServer }}
+{{ if hugo.IsServer }}
 	{{ $script := $script | fingerprint }}
 	<script src="{{ $script.Permalink }}"></script>
 {{ else }}

--- a/theme.toml
+++ b/theme.toml
@@ -14,6 +14,7 @@ homepage = "https://min.io/"
 [params]
 footerText = 'This work is licensed under a Creative Commons Attribution 4.0 International License. 2020-Present, MinIO, Inc.'
 homeLink = '/'
+enableGitInfo = true
 
 [markup]
 [markup.tableOfContents]


### PR DESCRIPTION
In the upcoming Hugo 0.137.0 release, two params we use are being removed having been deprecated in 0.120.0 and 0.124.0. This fixes those params to the suggested updates. These deprecated params are causing build errors on 0.136.1.

Hugo 0.129.0 updated **GitInfo** and requires that we add a new line when setting up repos.
This modifies the `[Params]` section of `theme.toml` to include the new required line.