### PR TITLE
Prevent dark mode from being automatically applied based on local storage settings

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,3 +1,4 @@
+<!-- 
 <script>
 	var isDmActive = JSON.parse(localStorage.getItem("dark-mode")) || false;
 	var isRmActive = JSON.parse(localStorage.getItem("read-mode")) || false;
@@ -5,7 +6,7 @@
 	document.documentElement.classList.toggle("read-mode", isRmActive);
 	document.documentElement.classList.toggle("dark", isDmActive);
 </script>
-
+-->
 {{ $script := resources.Get "/dist/app.js" }}
 
 <!-- 


### PR DESCRIPTION
We’ve temporarily disabled dark mode for the new website launch, as we couldn’t manage a full-scale change within the timeline. As part of this, I’m also removing some dark mode settings to prevent issues like the one Harsha experienced.