### PR TITLE
Adding literalinclude shortcode

### DIFF
--- a/layouts/shortcodes/literalinclude.html
+++ b/layouts/shortcodes/literalinclude.html
@@ -1,0 +1,1 @@
+{{ readFile (.Get 0) }}


### PR DESCRIPTION
# Summary

I ran into an issue where our existing `include` shortcode runs `markdownify`, which causes issues when passing in a source code file that uses `#` as a comment delimiter.

So this adds a `literalinclude` shortcode for just pulling a file in and presenting it as-is.